### PR TITLE
Replace deprecated 'netaddr' library with 'netip' in standard library

### DIFF
--- a/firewall/client.go
+++ b/firewall/client.go
@@ -6,10 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"net/netip"
+
 	"cloud.google.com/go/civil"
 	"github.com/corbaltcode/go-akamai"
 	"github.com/corbaltcode/go-akamai/internal/request"
-	"inet.af/netaddr"
 )
 
 const basePath = "/firewall-rules-manager/v1/"
@@ -64,13 +65,13 @@ type CIDRBlock struct {
 	ID            int
 	ServiceID     int
 	ServiceName   string
-	CIDR          netaddr.IPPrefix
+	CIDR          netip.Prefix
 	Ports         []int
 	CreationDate  civil.Date
 	EffectiveDate civil.Date
 	ChangeDate    civil.Date
-	MinIP         netaddr.IP
-	MaxIP         netaddr.IP
+	MinIP         netip.Addr
+	MaxIP         netip.Addr
 	LastAction    LastAction
 }
 
@@ -82,7 +83,7 @@ func newCIDRBlockFromResp(r cidrBlockResp) (CIDRBlock, error) {
 	v.ServiceID = r.ServiceID
 	v.ServiceName = r.ServiceName
 
-	v.CIDR, err = netaddr.ParseIPPrefix(r.CIDR + r.CIDRMask)
+	v.CIDR, err = netip.ParsePrefix(r.CIDR + r.CIDRMask)
 	if err != nil {
 		return CIDRBlock{}, err
 	}
@@ -120,11 +121,11 @@ func newCIDRBlockFromResp(r cidrBlockResp) (CIDRBlock, error) {
 		}
 	}
 
-	v.MinIP, err = netaddr.ParseIP(r.MinIP)
+	v.MinIP, err = netip.ParseAddr(r.MinIP)
 	if err != nil {
 		return CIDRBlock{}, err
 	}
-	v.MaxIP, err = netaddr.ParseIP(r.MaxIP)
+	v.MaxIP, err = netip.ParseAddr(r.MaxIP)
 	if err != nil {
 		return CIDRBlock{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,6 @@ go 1.17
 require (
 	cloud.google.com/go v0.99.0
 	gopkg.in/ini.v1 v1.66.2
-	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
 )
 
-require (
-	github.com/stretchr/testify v1.7.0 // indirect
-	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
-)
+require github.com/stretchr/testify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,7 +61,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -180,10 +179,6 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29 h1:UXLjNohABv4S58tHmeuIZDO6e3mHpW2Dx33gaNt03LE=
-go4.org/intern v0.0.0-20211027215823-ae77deb06f29/go.mod h1:cS2ma+47FKrLPdXFpr7CuxiTW3eyJbWew4qx0qtQWDA=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -549,8 +544,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6 h1:acCzuUSQ79tGsM/O50VRFySfMm19IoMKL+sZztZkCxw=
-inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6/go.mod h1:y3MGhcFMlh0KZPMuXXow8mpjxxAk3yoDNsp4cQz54i8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/siteshield/client.go
+++ b/siteshield/client.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"time"
 
+	"net/netip"
+
 	"github.com/corbaltcode/go-akamai"
 	"github.com/corbaltcode/go-akamai/internal/request"
-	"inet.af/netaddr"
 )
 
 const basePath = "/siteshield/v1/"
@@ -62,11 +63,11 @@ type Map struct {
 	AcknowledgedBy        string
 	Alias                 string
 	Contacts              []string
-	CurrentCIDRs          []netaddr.IPPrefix
+	CurrentCIDRs          []netip.Prefix
 	ID                    int
 	IsShared              bool
 	LatestTicketID        int
-	ProposedCIDRs         []netaddr.IPPrefix
+	ProposedCIDRs         []netip.Prefix
 	RuleName              string
 	Service               Service
 	SureRouteName         string
@@ -83,9 +84,9 @@ func newMapFromResp(r mapResp) (Map, error) {
 	m.Contacts = make([]string, len(r.Contacts))
 	copy(m.Contacts, r.Contacts)
 
-	m.CurrentCIDRs = make([]netaddr.IPPrefix, len(r.CurrentCIDRs))
+	m.CurrentCIDRs = make([]netip.Prefix, len(r.CurrentCIDRs))
 	for i, str := range r.CurrentCIDRs {
-		prefix, err := netaddr.ParseIPPrefix(str)
+		prefix, err := netip.ParsePrefix(str)
 		if err != nil {
 			return Map{}, err
 		}
@@ -96,9 +97,9 @@ func newMapFromResp(r mapResp) (Map, error) {
 	m.IsShared = r.Shared
 	m.LatestTicketID = r.LatestTicketID
 
-	m.ProposedCIDRs = make([]netaddr.IPPrefix, len(r.ProposedCIDRs))
+	m.ProposedCIDRs = make([]netip.Prefix, len(r.ProposedCIDRs))
 	for i, str := range r.ProposedCIDRs {
-		prefix, err := netaddr.ParseIPPrefix(str)
+		prefix, err := netip.ParsePrefix(str)
 		if err != nil {
 			return Map{}, err
 		}


### PR DESCRIPTION
## PR Description

Go added `netip` to the standard library in Go 1.18 in March 2022, found in `net/netip`. It was designed to replace parts of net and the external `inet.af/netaddr` package.

netaddr's repo [here](https://github.com/inetaf/netaddr) is archived and now states:

> This package is deprecated and will not receive updates. Use net/netip in the Go standard library instead

## PR Checklist
* [ ] **New automated tests have been written to the extent possible.**
* [X] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [x] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**


1. I've tested this by following these instructions:
- Setup up your `.edgerc` config properly with a [firewall] and [site-shield] section containing the corresponding service credentials from akamai
- Run `akamai firewall list-services` and `akamai site-shield list-maps` to obtain the `map-id` and `service-id` needed for the script.

2. Run this through the `diff-prefix-list` repo. Navigate to the root directory and run ```go get github.com/corbaltcode/go-akamai@190e7e7ff127c39a89d57ba694ba2da11955f76d```, which pulls this commit, then `go mod tidy`

3. Next, prepare to run the `diff-prefix-list` code, which requires setting the relevant AWS keys

4. Finally, run the above `service id` and `map id` values to query the akamai services for their prefix lists. This will then test against our existing AWS prefix list. I do this for `site-shield` and for `firewall`
`go run . -name [prefix-list-name] -address-family IPv4 -source akamai-firewall-rules -service-id [service-id]`
`go run . -name [prefix-list-name] -address-family IPv4 -source akamai-site-shield -map-id [map-id]`

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
