### PR TITLE
Upgrade Go from 1.17->1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/corbaltcode/go-akamai
 
-go 1.17
+go 1.24
 
 require (
 	cloud.google.com/go v0.99.0


### PR DESCRIPTION
## PR Description

Go 1.17 was deprecated 3 years ago, we should upgrade to the latest stable version: Go 1.24.

You can test this by running`go get github.com/corbaltcode/go-akamai@0fac0db18561848a75518d86bdd05f3df950e6e7` in the `diff-prefix-lists` repo and making sure the functionality works using the CLI. 

## PR Checklist
* [x] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [x] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

