### PR TITLE
Show debugging output on HTTP requests

### DIFF
--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 
 	"github.com/corbaltcode/go-akamai"
@@ -15,14 +16,17 @@ import (
 const scheme = "https"
 
 func Do(c akamai.Credentials, method string, path string, in []byte, out *[]byte) error {
-	req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s", scheme, c.Host, path), bytes.NewReader(in))
+	url := fmt.Sprintf("%s://%s%s", scheme, c.Host, path)
+	req, err := http.NewRequest(method, url, bytes.NewReader(in))
 	if err != nil {
+		log.Printf("Error creating request: %v", err)
 		return err
 	}
 	req.Header.Add("Accept", "application/json")
 
 	authHeader, err := edgegrid.GenerateAuthHeader(c, method, scheme, path, in)
 	if err != nil {
+		log.Printf("Error generating auth header: %v", err)
 		return err
 	}
 	req.Header.Add("Authorization", authHeader)
@@ -32,16 +36,22 @@ func Do(c akamai.Credentials, method string, path string, in []byte, out *[]byte
 		req.Header.Add("Content-Length", fmt.Sprintf("%d", len(in)))
 	}
 
+	log.Printf("%s %s", method, url)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		log.Printf("Request failed: %v", err)
 		return err
 	}
 
 	defer resp.Body.Close()
 	*out, err = io.ReadAll(resp.Body)
 	if err != nil {
+		log.Printf("Error reading response body: %v", err)
 		return err
 	}
+
+	log.Printf("Response status: %d", resp.StatusCode)
+	log.Printf("Response body -------------------------\n%s\n-----------------------------", string(*out))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return errors.New(string(*out))


### PR DESCRIPTION
## PR Description
Show debugging output on HTTP requests.

We're having an issue where the prefix list job is generating results that are inconsistent with what the Akamai API returns from a bare `curl` request. This is to help diagnose the result.

## PR Checklist
* [x] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- go build run
